### PR TITLE
MessageEdit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.wire.bots</groupId>
     <artifactId>lithium</artifactId>
-    <version>2.20.8</version>
+    <version>2.21.0</version>
     <packaging>jar</packaging>
 
     <repositories>

--- a/src/main/java/com/wire/bots/sdk/BotClient.java
+++ b/src/main/java/com/wire/bots/sdk/BotClient.java
@@ -52,21 +52,21 @@ public class BotClient implements WireClient {
 
     @Override
     public UUID sendText(String txt) throws Exception {
-        Text generic = new Text(txt);
+        MessageText generic = new MessageText(txt);
         postGenericMessage(generic);
         return generic.getMessageId();
     }
 
     @Override
     public UUID sendText(String txt, long expires) throws Exception {
-        Text generic = new Text(txt, expires);
+        MessageText generic = new MessageText(txt, expires);
         postGenericMessage(generic);
         return generic.getMessageId();
     }
 
     @Override
     public UUID sendDirectText(String txt, String userId) throws Exception {
-        Text generic = new Text(txt);
+        MessageText generic = new MessageText(txt);
         postGenericMessage(generic, userId);
         return generic.getMessageId();
     }
@@ -228,8 +228,17 @@ public class BotClient implements WireClient {
     }
 
     @Override
-    public void deleteMessage(UUID msgId) throws Exception {
-        postGenericMessage(new Delete(msgId));
+    public UUID deleteMessage(UUID msgId) throws Exception {
+        MessageDelete generic = new MessageDelete(msgId);
+        postGenericMessage(generic);
+        return generic.getMessageId();
+    }
+
+    @Override
+    public UUID editMessage(UUID replacingMessageId, String text) throws Exception {
+        MessageEdit generic = new MessageEdit(replacingMessageId, text);
+        postGenericMessage(generic);
+        return generic.getMessageId();
     }
 
     @Override

--- a/src/main/java/com/wire/bots/sdk/WireClient.java
+++ b/src/main/java/com/wire/bots/sdk/WireClient.java
@@ -163,7 +163,17 @@ public interface WireClient extends Closeable {
      * @param msgId Message ID
      * @throws Exception
      */
-    void deleteMessage(UUID msgId) throws Exception;
+    UUID deleteMessage(UUID msgId) throws Exception;
+
+    /**
+     * Post Like for a message
+     *
+     * @param replacingMessageId Message ID that is being edited
+     * @param text               New text
+     * @return MessageId
+     * @throws Exception
+     */
+    UUID editMessage(UUID replacingMessageId, String text) throws Exception;
 
     /**
      * This method downloads asset from the Backend.

--- a/src/main/java/com/wire/bots/sdk/assets/MessageDelete.java
+++ b/src/main/java/com/wire/bots/sdk/assets/MessageDelete.java
@@ -4,11 +4,11 @@ import com.waz.model.Messages;
 
 import java.util.UUID;
 
-public class Delete implements IGeneric {
+public class MessageDelete implements IGeneric {
     private final UUID delMessageId;
     private final UUID messageId = UUID.randomUUID();
 
-    public Delete(UUID delMessageId) {
+    public MessageDelete(UUID delMessageId) {
         this.delMessageId = delMessageId;
     }
 

--- a/src/main/java/com/wire/bots/sdk/assets/MessageEdit.java
+++ b/src/main/java/com/wire/bots/sdk/assets/MessageEdit.java
@@ -1,0 +1,36 @@
+package com.wire.bots.sdk.assets;
+
+import com.waz.model.Messages;
+
+import java.util.UUID;
+
+public class MessageEdit implements IGeneric {
+    private final UUID replacingMessageId;
+    private final String text;
+    private final UUID messageId = UUID.randomUUID();
+
+    public MessageEdit(UUID replacingMessageId, String text) {
+        this.replacingMessageId = replacingMessageId;
+        this.text = text;
+    }
+
+    @Override
+    public Messages.GenericMessage createGenericMsg() {
+        Messages.Text.Builder text = Messages.Text.newBuilder()
+                .setContent(this.text);
+
+        Messages.MessageEdit.Builder messageEdit = Messages.MessageEdit.newBuilder()
+                .setReplacingMessageId(replacingMessageId.toString())
+                .setText(text);
+
+        return Messages.GenericMessage.newBuilder()
+                .setMessageId(getMessageId().toString())
+                .setEdited(messageEdit)
+                .build();
+    }
+
+    @Override
+    public UUID getMessageId() {
+        return messageId;
+    }
+}

--- a/src/main/java/com/wire/bots/sdk/assets/MessageText.java
+++ b/src/main/java/com/wire/bots/sdk/assets/MessageText.java
@@ -22,17 +22,17 @@ import com.waz.model.Messages;
 
 import java.util.UUID;
 
-public class Text implements IGeneric {
+public class MessageText implements IGeneric {
     private final String text;
     private final long expires;
     private UUID messageId = UUID.randomUUID();
 
-    public Text(String text) {
+    public MessageText(String text) {
         this.text = text;
         this.expires = 0;
     }
 
-    public Text(String text, long expires) {
+    public MessageText(String text, long expires) {
         this.text = text;
         this.expires = expires;
     }

--- a/src/main/java/com/wire/bots/sdk/user/UserClient.java
+++ b/src/main/java/com/wire/bots/sdk/user/UserClient.java
@@ -51,14 +51,14 @@ public class UserClient implements WireClient {
     }
 
     public UUID sendText(String txt) throws Exception {
-        Text generic = new Text(txt);
+        MessageText generic = new MessageText(txt);
         postGenericMessage(generic);
         return generic.getMessageId();
     }
 
     @Override
     public UUID sendText(String txt, long expires) throws Exception {
-        Text generic = new Text(txt, expires);
+        MessageText generic = new MessageText(txt, expires);
         postGenericMessage(generic);
         return generic.getMessageId();
     }
@@ -195,8 +195,17 @@ public class UserClient implements WireClient {
     }
 
     @Override
-    public void deleteMessage(UUID msgId) throws Exception {
-        postGenericMessage(new Delete(msgId));
+    public UUID deleteMessage(UUID msgId) throws Exception {
+        MessageDelete generic = new MessageDelete(msgId);
+        postGenericMessage(generic);
+        return generic.getMessageId();
+    }
+
+    @Override
+    public UUID editMessage(UUID replacingMessageId, String text) throws Exception {
+        MessageEdit generic = new MessageEdit(replacingMessageId, text);
+        postGenericMessage(generic);
+        return generic.getMessageId();
     }
 
     @Override


### PR DESCRIPTION
Add support for message editing.
Only messages sent by the bot can be edited by the bot

```
    UUID editMessage(UUID replacingMessageId, String text) throws Exception;
```

How to use it:
```
WireClient aliceClient = new BotClient(...);
UUID messageId = aliceClient.sendText("Hello Bob, this is alice!");
aliceClient.editMessage(messageId, "Hello Bob, this is Alice!");
```
#21 