### PR TITLE
Introduce version endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@
 <dependencies>
 ```
 
+If you want to use [Version]() resource (API endpoint), you must create version file during the build.
+For example, during the Docker build, one can put following code inside `Dockerfile`:
+```dockerfile
+# create version file
+ARG release_version=development
+ENV RELEASE_FILE_PATH=/path/to/release.txt
+RUN echo $release_version > $RELEASE_FILE_PATH
+```
+And than add build argument ie. in the build pipeline 
+[like that](https://github.com/dkovacevic/roman/blob/8d41bcba20a8f7607210263944c9ccecd757ed44/.github/workflows/release.yml#L26).
+
 ### Tutorial:
 - [Echo Bot](https://github.com/wireapp/echo-bot)
 

--- a/src/main/java/com/wire/bots/sdk/Server.java
+++ b/src/main/java/com/wire/bots/sdk/Server.java
@@ -35,6 +35,7 @@ import com.wire.bots.sdk.server.filters.AuthenticationFeature;
 import com.wire.bots.sdk.server.resources.BotsResource;
 import com.wire.bots.sdk.server.resources.EmptyStatusResource;
 import com.wire.bots.sdk.server.resources.MessageResource;
+import com.wire.bots.sdk.server.resources.VersionResource;
 import com.wire.bots.sdk.server.tasks.AvailablePrekeysTask;
 import com.wire.bots.sdk.server.tasks.ConversationTask;
 import com.wire.bots.sdk.state.FileState;
@@ -196,7 +197,10 @@ public abstract class Server<Config extends Configuration> extends Application<C
     }
 
     private void runInBotMode() {
+        // add status endpoint
         addResource(new EmptyStatusResource());
+        // add version endpoint
+        addResource(new VersionResource());
 
         botResource();
         messageResource();

--- a/src/main/java/com/wire/bots/sdk/server/model/Version.java
+++ b/src/main/java/com/wire/bots/sdk/server/model/Version.java
@@ -1,0 +1,13 @@
+package com.wire.bots.sdk.server.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.constraints.NotNull;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Version {
+    @JsonProperty
+    @NotNull
+    public String version;
+}

--- a/src/main/java/com/wire/bots/sdk/server/resources/VersionResource.java
+++ b/src/main/java/com/wire/bots/sdk/server/resources/VersionResource.java
@@ -1,0 +1,47 @@
+package com.wire.bots.sdk.server.resources;
+
+import com.wire.bots.sdk.server.model.Version;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.io.RandomAccessFile;
+
+@Api
+@Path("/version")
+@Produces(MediaType.APPLICATION_JSON)
+public class VersionResource {
+    @GET
+    @ApiOperation(value = "Returns version of the running code.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, response = Version.class, message = "Version")
+    })
+    public Response get() {
+        return Response
+                .ok(getVersion())
+                .build();
+    }
+
+    private Version getVersion() {
+        final String path = System.getenv("RELEASE_FILE_PATH");
+        final Version version = new Version();
+
+        if (path != null) {
+            try (RandomAccessFile file = new RandomAccessFile(path, "r")) {
+                version.version = file.readLine();
+            } catch (Exception ignored) {
+            }
+        }
+
+        if (version.version == null) {
+            version.version = "development";
+        }
+        return version;
+    }
+}


### PR DESCRIPTION
As we started using versioning endpoint in Charon, Echo Bot and Roman, it is probably better to put `/version` resource directly to the lithium and not to every time copy paste it to other projects.