### PR TITLE
Set system props from the config upon Init

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.wire.bots</groupId>
     <artifactId>lithium</artifactId>
-    <version>2.36.5</version>
+    <version>2.37.0</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/com/wire/bots/sdk/API.java
+++ b/src/main/java/com/wire/bots/sdk/API.java
@@ -95,7 +95,7 @@ public class API implements Backend {
     }
 
     private String host() {
-        String host = System.getenv("WIRE_API_HOST");
+        String host = System.getProperty(Configuration.WIRE_BOTS_SDK_API, System.getenv("WIRE_API_HOST"));
         return host != null ? host : "https://prod-nginz-https.wire.com";
     }
 

--- a/src/main/java/com/wire/bots/sdk/Configuration.java
+++ b/src/main/java/com/wire/bots/sdk/Configuration.java
@@ -32,9 +32,17 @@ import javax.validation.constraints.NotNull;
  * Application configuration class. Extend this class to add your custom configuration
  */
 public class Configuration extends io.dropwizard.Configuration {
-    @JsonProperty("database")
+    public static final String WIRE_BOTS_SDK_TOKEN = "wire.bots.sdk.token";
+    public static final String WIRE_BOTS_SDK_API = "wire.bots.sdk.api";
+    public static final String WIRE_BOTS_SDK_WS = "wire.bots.sdk.ws";
+
+    @JsonProperty
     @NotNull
     public Database database;
+
+    @JsonProperty
+    @NotNull
+    public String token;   // Service token. Obtained when the Service is registered with Wire
 
     @Valid
     private _JerseyClientConfiguration jerseyClient = new _JerseyClientConfiguration();

--- a/src/main/java/com/wire/bots/sdk/Server.java
+++ b/src/main/java/com/wire/bots/sdk/Server.java
@@ -128,6 +128,10 @@ public abstract class Server<Config extends Configuration> extends Application<C
         this.config = config;
         this.environment = env;
 
+        System.setProperty(Configuration.WIRE_BOTS_SDK_TOKEN, config.token);
+        System.setProperty(Configuration.WIRE_BOTS_SDK_API, config.apiHost);
+        System.setProperty(Configuration.WIRE_BOTS_SDK_WS, config.wsHost);
+
         migrateDBifNeeded(config.database);
 
         jdbi = buildJdbi(config.database, env);

--- a/src/main/java/com/wire/bots/sdk/server/filters/AuthenticationFilter.java
+++ b/src/main/java/com/wire/bots/sdk/server/filters/AuthenticationFilter.java
@@ -1,5 +1,7 @@
 package com.wire.bots.sdk.server.filters;
 
+import com.wire.bots.sdk.Configuration;
+
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
@@ -33,7 +35,7 @@ public class AuthenticationFilter implements ContainerRequestFilter {
             throw new WebApplicationException(cause, Response.Status.BAD_REQUEST);
         }
 
-        String serviceToken = System.getenv("SERVICE_TOKEN");
+        String serviceToken = System.getProperty(Configuration.WIRE_BOTS_SDK_TOKEN, System.getenv("SERVICE_TOKEN"));
 
         if (!Objects.equals(token, serviceToken)) {
             Exception cause = new IllegalArgumentException("Wrong service token");

--- a/src/main/java/com/wire/bots/sdk/user/LoginClient.java
+++ b/src/main/java/com/wire/bots/sdk/user/LoginClient.java
@@ -19,6 +19,7 @@
 package com.wire.bots.sdk.user;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.wire.bots.sdk.Configuration;
 import com.wire.bots.sdk.exceptions.AuthException;
 import com.wire.bots.sdk.exceptions.HttpException;
 import com.wire.bots.sdk.models.otr.PreKey;
@@ -69,7 +70,7 @@ public class LoginClient {
     }
 
     public String host() {
-        String host = System.getenv("WIRE_API_HOST");
+        String host = System.getProperty(Configuration.WIRE_BOTS_SDK_API, System.getenv("WIRE_API_HOST"));
         return host != null ? host : "https://prod-nginz-https.wire.com";
     }
 


### PR DESCRIPTION
Introduced `NotNull` property `token` in the Configuration base class
Set `System.Prop` from config properties during Init in order to be able to use them in the classes where Config obj is not available
Those properties are:
```
public static final String WIRE_BOTS_SDK_TOKEN = "wire.bots.sdk.token";
public static final String WIRE_BOTS_SDK_API = "wire.bots.sdk.api";
public static final String WIRE_BOTS_SDK_WS = "wire.bots.sdk.ws";
```

Example how the correct yaml should look like now:
```
...
token: ${SERVICE_TOKEN:-}
apiHost: ${WIRE_API_HOST:-https://prod-nginz-https.wire.com}
wsHost:  ${WIRE_WS_HOST:-wss://prod-nginz-ssl.wire.com}
...
```