### PR TITLE
Build lithium for Java 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ libs/
 .classpath
 .project
 .settings
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.wire</groupId>
     <artifactId>lithium</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -120,7 +120,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <release>14</release>
+                    <release>8</release>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
As Lithium is not using anything new in the Java, it would be better to maintain compatibility with the Java 8.

Fixes build in Don Bot