### PR TITLE
Fix incorrect warning message

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -54,7 +54,7 @@ check_tools() {
 
 check_auth() {
     if [ ! -f "./.cookie" ]; then
-        echo "Not authenticated. Use the 'auth' command."
+        echo "Not authenticated. Use the 'auth-provider' command."
         exit 1
     fi
 }


### PR DESCRIPTION
The name of the command in the warning message was wrong.